### PR TITLE
Handle errors first and disregard byte when error exists

### DIFF
--- a/pass.go
+++ b/pass.go
@@ -21,7 +21,10 @@ func getPasswd(masked bool) ([]byte, error) {
 	}
 
 	for {
-		if v, e := getch(); v == 127 || v == 8 {
+		if v, e := getch(); e != nil {
+			err = e
+			break
+		} else if v == 127 || v == 8 {
 			if l := len(pass); l > 0 {
 				pass = pass[:l-1]
 				fmt.Print(string(bs))
@@ -34,9 +37,6 @@ func getPasswd(masked bool) ([]byte, error) {
 		} else if v != 0 {
 			pass = append(pass, v)
 			fmt.Print(string(mask))
-		} else if e != nil {
-			err = e
-			break
 		}
 	}
 	fmt.Println()

--- a/pass_test.go
+++ b/pass_test.go
@@ -2,6 +2,7 @@ package gopass
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -95,6 +96,32 @@ func TestGetPasswd(t *testing.T) {
 			if input.Len() != d.byesLeft {
 				t.Errorf("Expected %v bytes left on buffer but instead got %v when masked=%v. %s", d.byesLeft, input.Len(), masked, d.reason)
 			}
+		}
+	}
+}
+
+// TestGetPasswd_Err tests errors are properly handled from getch()
+func TestGetPasswd_Err(t *testing.T) {
+	var inBuffer *bytes.Buffer
+	getch = func() (byte, error) {
+		b, err := inBuffer.ReadByte()
+		if err != nil {
+			return 13, err
+		}
+		if b == 'z' {
+			return 'z', fmt.Errorf("Forced error; byte returned should not be considered accurate.")
+		}
+		return b, nil
+	}
+
+	for input, expectedPassword := range map[string]string{"abc": "abc", "abzc": "ab"} {
+		inBuffer = bytes.NewBufferString(input)
+		p, err := GetPasswdMasked()
+		if string(p) != expectedPassword {
+			t.Errorf("Expected %q but got %q instead.", expectedPassword, p)
+		}
+		if err == nil {
+			t.Errorf("Expected error to be returned.")
 		}
 	}
 }

--- a/win.go
+++ b/win.go
@@ -41,6 +41,6 @@ var getch = func() (byte, error) {
 	if result > 0 {
 		return line[0], nil
 	} else {
-		return 13, err
+		return 0, err
 	}
 }


### PR DESCRIPTION
Fixes a problem where error cases were usually simply treated
as `enter` presses on Windows and nil bytes on *nix.  This was
a result of the error case being handled last rather than first.

Any byte that comes back along with an error should be disregarded.

Added test cases that confirm this behavior.
